### PR TITLE
Enable analytics platform comms to pre-prod DB AZ2 route

### DIFF
--- a/transit-gateway-analytics-platform/routes-analytical-platform-pre-prod.tf
+++ b/transit-gateway-analytics-platform/routes-analytical-platform-pre-prod.tf
@@ -51,12 +51,12 @@
 //   count                  = "${local.env_create_analytics_prod_routes}"
 // }
 
-// resource "aws_route" "transit_gateway_route_vpc_db-routetable-az2-apde-prod" {
-//   route_table_id         = "${data.terraform_remote_state.vpc.vpc_db-routetable-az2}"
-//   transit_gateway_id     = "${data.terraform_remote_state.common.transit_gateway_id}"
-//   destination_cidr_block = "${local.analyticalplatform_prod_cidr_range}"
-//   count                  = "${local.env_create_analytics_prod_routes}"
-// }
+resource "aws_route" "transit_gateway_route_vpc_db-routetable-az2-apde-prod" {
+   route_table_id         = "${data.terraform_remote_state.vpc.vpc_db-routetable-az2}"
+   transit_gateway_id     = "${data.terraform_remote_state.common.transit_gateway_id}"
+   destination_cidr_block = "${local.analyticalplatform_pre_prod_cidr_range}"
+   count                  = "${local.env_create_analytics_pre_prod_routes}"
+}
 
 resource "aws_route" "transit_gateway_route_vpc_db-routetable-az3-apde-pre-prod" {
   route_table_id         = "${data.terraform_remote_state.vpc.vpc_db-routetable-az3}"

--- a/transit-gateway-analytics-platform/routes-analytical-platform-pre-prod.tf
+++ b/transit-gateway-analytics-platform/routes-analytical-platform-pre-prod.tf
@@ -51,7 +51,7 @@
 //   count                  = "${local.env_create_analytics_prod_routes}"
 // }
 
-resource "aws_route" "transit_gateway_route_vpc_db-routetable-az2-apde-prod" {
+resource "aws_route" "transit_gateway_route_vpc_db-routetable-az2-apde-pre-prod" {
    route_table_id         = "${data.terraform_remote_state.vpc.vpc_db-routetable-az2}"
    transit_gateway_id     = "${data.terraform_remote_state.common.transit_gateway_id}"
    destination_cidr_block = "${local.analyticalplatform_pre_prod_cidr_range}"

--- a/transit-gateway-cloud-platform/locals.tf
+++ b/transit-gateway-cloud-platform/locals.tf
@@ -28,7 +28,13 @@ locals {
     delius-pre-prod     = "1"
     delius-prod         = "1"
   }
-
   env_create_cloudplatform_routes = "${lookup(local.create_cloudplatform_routes, "${local.environment_name}" , 0) }"
+
+  create_i2n_routes = {
+    delius-core-dev     = "1"
+    delius-stage        = "1"
+    delius-prod         = "1"
+  }
+  env_create_i2n_routes = "${lookup(local.create_i2n_routes, "${local.environment_name}" , 0) }"
 
 }

--- a/transit-gateway-cloud-platform/routes-i2n.tf
+++ b/transit-gateway-cloud-platform/routes-i2n.tf
@@ -5,79 +5,71 @@
 # Routes to I2N AZ1 via transit gateways
 #================================================
 resource "aws_route" "transit_gateway_route_vpc_private-routetable-az1-i2n-az1" {
-  count                  = "${local.env_create_cloudplatform_routes}"
+  count                  = "${local.env_create_i2n_routes}"
   route_table_id         = "${data.terraform_remote_state.vpc.vpc_private-routetable-az1}"
   transit_gateway_id     = "${data.terraform_remote_state.common.transit_gateway_id}"
   destination_cidr_block = "${local.i2n_az1_cidr_range}"
-  count                  = "${local.env_create_cloudplatform_routes}"
 }
 
 resource "aws_route" "transit_gateway_route_vpc_private-routetable-az2-i2n-az1" {
-  count                  = "${local.env_create_cloudplatform_routes}"
+  count                  = "${local.env_create_i2n_routes}"
   route_table_id         = "${data.terraform_remote_state.vpc.vpc_private-routetable-az2}"
   transit_gateway_id     = "${data.terraform_remote_state.common.transit_gateway_id}"
   destination_cidr_block = "${local.i2n_az1_cidr_range}"
-  count                  = "${local.env_create_cloudplatform_routes}"
 }
 
 resource "aws_route" "transit_gateway_route_vpc_private-routetable-az3-i2n-az1" {
-  count                  = "${local.env_create_cloudplatform_routes}"
+  count                  = "${local.env_create_i2n_routes}"
   route_table_id         = "${data.terraform_remote_state.vpc.vpc_private-routetable-az3}"
   transit_gateway_id     = "${data.terraform_remote_state.common.transit_gateway_id}"
   destination_cidr_block = "${local.i2n_az1_cidr_range}"
-  count                  = "${local.env_create_cloudplatform_routes}"
 }
 
 #================================================
 # Routes to I2N AZ2 via transit gateways
 #================================================
 resource "aws_route" "transit_gateway_route_vpc_private-routetable-az1-i2n-az2" {
-  count                  = "${local.env_create_cloudplatform_routes}"
+  count                  = "${local.env_create_i2n_routes}"
   route_table_id         = "${data.terraform_remote_state.vpc.vpc_private-routetable-az1}"
   transit_gateway_id     = "${data.terraform_remote_state.common.transit_gateway_id}"
   destination_cidr_block = "${local.i2n_az2_cidr_range}"
-  count                  = "${local.env_create_cloudplatform_routes}"
 }
 
 resource "aws_route" "transit_gateway_route_vpc_private-routetable-az2-i2n-az2" {
-  count                  = "${local.env_create_cloudplatform_routes}"
+  count                  = "${local.env_create_i2n_routes}"
   route_table_id         = "${data.terraform_remote_state.vpc.vpc_private-routetable-az2}"
   transit_gateway_id     = "${data.terraform_remote_state.common.transit_gateway_id}"
   destination_cidr_block = "${local.i2n_az2_cidr_range}"
-  count                  = "${local.env_create_cloudplatform_routes}"
 }
 
 resource "aws_route" "transit_gateway_route_vpc_private-routetable-az3-i2n-az2" {
-  count                  = "${local.env_create_cloudplatform_routes}"
+  count                  = "${local.env_create_i2n_routes}"
   route_table_id         = "${data.terraform_remote_state.vpc.vpc_private-routetable-az3}"
   transit_gateway_id     = "${data.terraform_remote_state.common.transit_gateway_id}"
   destination_cidr_block = "${local.i2n_az2_cidr_range}"
-  count                  = "${local.env_create_cloudplatform_routes}"
 }
 
 #================================================
 # Routes to I2N AZ3 via transit gateways
 #================================================
 resource "aws_route" "transit_gateway_route_vpc_private-routetable-az1-i2n-az3" {
-  count                  = "${local.env_create_cloudplatform_routes}"
+  count                  = "${local.env_create_i2n_routes}"
   route_table_id         = "${data.terraform_remote_state.vpc.vpc_private-routetable-az1}"
   transit_gateway_id     = "${data.terraform_remote_state.common.transit_gateway_id}"
   destination_cidr_block = "${local.i2n_az3_cidr_range}"
-  count                  = "${local.env_create_cloudplatform_routes}"
 }
 
 resource "aws_route" "transit_gateway_route_vpc_private-routetable-az2-i2n-az3" {
-  count                  = "${local.env_create_cloudplatform_routes}"
+  count                  = "${local.env_create_i2n_routes}"
   route_table_id         = "${data.terraform_remote_state.vpc.vpc_private-routetable-az2}"
   transit_gateway_id     = "${data.terraform_remote_state.common.transit_gateway_id}"
   destination_cidr_block = "${local.i2n_az3_cidr_range}"
-  count                  = "${local.env_create_cloudplatform_routes}"
+
 }
 
 resource "aws_route" "transit_gateway_route_vpc_private-routetable-az3-i2n-az3" {
-  count                  = "${local.env_create_cloudplatform_routes}"
+  count                  = "${local.env_create_i2n_routes}"
   route_table_id         = "${data.terraform_remote_state.vpc.vpc_private-routetable-az3}"
   transit_gateway_id     = "${data.terraform_remote_state.common.transit_gateway_id}"
   destination_cidr_block = "${local.i2n_az3_cidr_range}"
-  count                  = "${local.env_create_cloudplatform_routes}"
 }


### PR DESCRIPTION
Work item https://dsdmoj.atlassian.net/browse/NIT-207

**PR contains**
- Enabling of route to pre-prod DB in AZ2
- Tidying up of some code
- Isolating route changes related to i2n - to ensure they don't get added to pre-prod

**Testing**
Some test plans in pre-prod show:
- Common component: no changes to common component (fine)
- AP component: addition of new route to pre-prod data AZ2 route table for AP (fine)
- AP test-rules component:new inbound AP test SG rule ("analytics_prod_test_ingress_delius_db_in_icmp") in pre-prod, allowing inbound ICMP, attached to delius-pre-prod-delius-core-db-in-from-mis. Assume this was coded up just for test reasons so could be removed if needed.
- CloudPlatform test-rules component: removal of 2 CloudPlatform SG rules (in SGs delius-pre-prod-delius-db-in and delius-pre-prod-weblogic-interface-instances) allowing inbound ICMP. Again, assume, this was coded up just for test reasons so could be removed if needed.
