### PR TITLE
Changes to routes to point to pttp tgw affecting delius-core-dev

### DIFF
--- a/transit-gateway-analytics-platform/locals.tf
+++ b/transit-gateway-analytics-platform/locals.tf
@@ -27,51 +27,44 @@ locals {
   analyticalplatform_prod_cidr_range = "172.25.0.0/16"
 
   
-
+  # Create variables used to determine when/where to create routes
   create_analytics_alpha_routes = {
     delius-pre-prod = "1"
   }
-
   env_create_analytics_alpha_routes = "${lookup(local.create_analytics_alpha_routes, "${local.environment_name}" , 0) }"
 
   create_analytics_dev_routes = {
     delius-core-sandpit = "1"
   }
-
   env_create_analytics_dev_routes = "${lookup(local.create_analytics_dev_routes, "${local.environment_name}" , 0) }"
 
   create_analytics_pre_prod_routes = {
     delius-pre-prod     = "1"
   }
- 
   env_create_analytics_pre_prod_routes = "${lookup(local.create_analytics_pre_prod_routes, "${local.environment_name}" , 0) }"
  
   create_analytics_prod_routes = {
     delius-pre-prod     = "1"
     delius-prod         = "1"
   }
-
   env_create_analytics_prod_routes = "${lookup(local.create_analytics_prod_routes, "${local.environment_name}" , 0) }"
   
   # Only create the security group ingress in these environments for Analytics ALPHA
   create_analytics_alpha_security_group_ingress = {
     delius-pre-prod = "1"
   }
-
   env_create_analytics_alpha_security_group_ingress = "${lookup(local.create_analytics_alpha_security_group_ingress, "${local.environment_name}" , 0) }"
 
   # Only create the security group ingress in these environments for Analytics DEV
   create_analytics_dev_security_group_ingress = {
     delius-core-sandpit = "1"
   }
-
   env_create_analytics_dev_security_group_ingress = "${lookup(local.create_analytics_dev_security_group_ingress, "${local.environment_name}" , 0) }"
 
   # Only create the security group ingress in these environments for Analytics PRE-PROD
   create_analytics_pre_prod_security_group_ingress = {
     delius-pre-prod     = "1"
   }
-
   env_create_analytics_pre_prod_security_group_ingress = "${lookup(local.create_analytics_pre_prod_security_group_ingress, "${local.environment_name}" , 0) }"
   
   # Only create the security group ingress in these environments for Analytics PROD
@@ -79,9 +72,6 @@ locals {
     delius-pre-prod     = "1"
     delius-prod         = "1"
   }
-
   env_create_analytics_prod_security_group_ingress = "${lookup(local.create_analytics_prod_security_group_ingress, "${local.environment_name}" , 0) }"
-  
-
 
 }

--- a/transit-gateway-analytics-platform/routes-analytical-platform-dev.tf
+++ b/transit-gateway-analytics-platform/routes-analytical-platform-dev.tf
@@ -5,7 +5,7 @@
 // resource "aws_route" "transit_gateway_route_vpc_public-routetable-az1-apde-dev" {
 //   count                  = "${local.env_create_analytics_dev_routes}"
 //   route_table_id         = "${data.terraform_remote_state.vpc.vpc_public-routetable-az1}"
-//   transit_gateway_id     = "${data.terraform_remote_state.common.transit_gateway_id}"
+//   transit_gateway_id     = "${data.terraform_remote_state.common.pttp_transit_gateway_id}"
 //   destination_cidr_block = "${local.analyticalplatform_dev_cidr_range}"
 //   count                  = "${local.env_env_create_analytics_dev_routes}"
 // }
@@ -13,55 +13,55 @@
 // resource "aws_route" "transit_gateway_route_vpc_public-routetable-az2-apde-dev" {
 //   count                  = "${local.env_create_analytics_dev_routes}"
 //   route_table_id         = "${data.terraform_remote_state.vpc.vpc_public-routetable-az2}"
-//   transit_gateway_id     = "${data.terraform_remote_state.common.transit_gateway_id}"
+//   transit_gateway_id     = "${data.terraform_remote_state.common.pttp_transit_gateway_id}"
 //   destination_cidr_block = "${local.analyticalplatform_dev_cidr_range}"
 // }
 
 // resource "aws_route" "transit_gateway_route_vpc_public-routetable-az3-apde-dev" {
 //   count                  = "${local.env_create_analytics_dev_routes}"
 //   route_table_id         = "${data.terraform_remote_state.vpc.vpc_public-routetable-az3}"
-//   transit_gateway_id     = "${data.terraform_remote_state.common.transit_gateway_id}"
+//   transit_gateway_id     = "${data.terraform_remote_state.common.pttp_transit_gateway_id}"
 //   destination_cidr_block = "${local.analyticalplatform_dev_cidr_range}"
 // }
 
 // resource "aws_route" "transit_gateway_route_vpc_private-routetable-az1-apde-dev" {
 //   count                  = "${local.env_create_analytics_dev_routes}"
 //   route_table_id         = "${data.terraform_remote_state.vpc.vpc_private-routetable-az1}"
-//   transit_gateway_id     = "${data.terraform_remote_state.common.transit_gateway_id}"
+//   transit_gateway_id     = "${data.terraform_remote_state.common.pttp_transit_gateway_id}"
 //   destination_cidr_block = "${local.analyticalplatform_dev_cidr_range}"
 // }
 
 // resource "aws_route" "transit_gateway_route_vpc_private-routetable-az2-apde-dev" {
 //   count                  = "${local.env_create_analytics_dev_routes}"
 //   route_table_id         = "${data.terraform_remote_state.vpc.vpc_private-routetable-az2}"
-//   transit_gateway_id     = "${data.terraform_remote_state.common.transit_gateway_id}"
+//   transit_gateway_id     = "${data.terraform_remote_state.common.pttp_transit_gateway_id}"
 //   destination_cidr_block = "${local.analyticalplatform_dev_cidr_range}"
 // }
 
 // resource "aws_route" "transit_gateway_route_vpc_private-routetable-az3-apde-dev" {
 //   count                  = "${local.env_create_analytics_dev_routes}"
 //   route_table_id         = "${data.terraform_remote_state.vpc.vpc_private-routetable-az3}"
-//   transit_gateway_id     = "${data.terraform_remote_state.common.transit_gateway_id}"
+//   transit_gateway_id     = "${data.terraform_remote_state.common.pttp_transit_gateway_id}"
 //   destination_cidr_block = "${local.analyticalplatform_dev_cidr_range}"
 // }
 
 // resource "aws_route" "transit_gateway_route_vpc_db-routetable-az1-apde-dev" {
 //   count                  = "${local.env_create_analytics_dev_routes}"
 //   route_table_id         = "${data.terraform_remote_state.vpc.vpc_db-routetable-az1}"
-//   transit_gateway_id     = "${data.terraform_remote_state.common.transit_gateway_id}"
+//   transit_gateway_id     = "${data.terraform_remote_state.common.pttp_transit_gateway_id}"
 //   destination_cidr_block = "${local.analyticalplatform_dev_cidr_range}"
 // }
 
 // resource "aws_route" "transit_gateway_route_vpc_db-routetable-az2-apde-dev" {
 //   count                  = "${local.env_create_analytics_dev_routes}"
 //   route_table_id         = "${data.terraform_remote_state.vpc.vpc_db-routetable-az2}"
-//   transit_gateway_id     = "${data.terraform_remote_state.common.transit_gateway_id}"
+//   transit_gateway_id     = "${data.terraform_remote_state.common.pttp_transit_gateway_id}"
 //   destination_cidr_block = "${local.analyticalplatform_dev_cidr_range}"
 // }
 
 resource "aws_route" "transit_gateway_route_vpc_db-routetable-az3-apde-dev" {
   route_table_id         = "${data.terraform_remote_state.vpc.vpc_db-routetable-az3}"
-  transit_gateway_id     = "${data.terraform_remote_state.common.transit_gateway_id}"
+  transit_gateway_id     = "${data.terraform_remote_state.common.pttp_transit_gateway_id}"
   destination_cidr_block = "${local.analyticalplatform_dev_cidr_range}"
   count                  = "${local.env_create_analytics_dev_routes}"
 }

--- a/transit-gateway-cloud-platform/routes-cloudplatform.tf
+++ b/transit-gateway-cloud-platform/routes-cloudplatform.tf
@@ -5,71 +5,62 @@
 resource "aws_route" "transit_gateway_route_vpc_public-routetable-az1" {
   count                  = "${local.env_create_cloudplatform_routes}"
   route_table_id         = "${data.terraform_remote_state.vpc.vpc_public-routetable-az1}"
-  transit_gateway_id     = "${data.terraform_remote_state.common.transit_gateway_id}"
+  transit_gateway_id     = "${data.terraform_remote_state.common.pttp_transit_gateway_id}"
   destination_cidr_block = "${local.cloudplatform_cidr_range}"
-  count                  = "${local.env_create_cloudplatform_routes}"
 }
 
 resource "aws_route" "transit_gateway_route_vpc_public-routetable-az2" {
   count                  = "${local.env_create_cloudplatform_routes}"
   route_table_id         = "${data.terraform_remote_state.vpc.vpc_public-routetable-az2}"
-  transit_gateway_id     = "${data.terraform_remote_state.common.transit_gateway_id}"
+  transit_gateway_id     = "${data.terraform_remote_state.common.pttp_transit_gateway_id}"
   destination_cidr_block = "${local.cloudplatform_cidr_range}"
-  count                  = "${local.env_create_cloudplatform_routes}"
 }
 
 resource "aws_route" "transit_gateway_route_vpc_public-routetable-az3" {
   count                  = "${local.env_create_cloudplatform_routes}"
   route_table_id         = "${data.terraform_remote_state.vpc.vpc_public-routetable-az3}"
-  transit_gateway_id     = "${data.terraform_remote_state.common.transit_gateway_id}"
+  transit_gateway_id     = "${data.terraform_remote_state.common.pttp_transit_gateway_id}"
   destination_cidr_block = "${local.cloudplatform_cidr_range}"
-  count                  = "${local.env_create_cloudplatform_routes}"
 }
 
 resource "aws_route" "transit_gateway_route_vpc_private-routetable-az1" {
   count                  = "${local.env_create_cloudplatform_routes}"
   route_table_id         = "${data.terraform_remote_state.vpc.vpc_private-routetable-az1}"
-  transit_gateway_id     = "${data.terraform_remote_state.common.transit_gateway_id}"
+  transit_gateway_id     = "${data.terraform_remote_state.common.pttp_transit_gateway_id}"
   destination_cidr_block = "${local.cloudplatform_cidr_range}"
-  count                  = "${local.env_create_cloudplatform_routes}"
 }
 
 resource "aws_route" "transit_gateway_route_vpc_private-routetable-az2" {
   count                  = "${local.env_create_cloudplatform_routes}"
   route_table_id         = "${data.terraform_remote_state.vpc.vpc_private-routetable-az2}"
-  transit_gateway_id     = "${data.terraform_remote_state.common.transit_gateway_id}"
+  transit_gateway_id     = "${data.terraform_remote_state.common.pttp_transit_gateway_id}"
   destination_cidr_block = "${local.cloudplatform_cidr_range}"
-  count                  = "${local.env_create_cloudplatform_routes}"
 }
 
 resource "aws_route" "transit_gateway_route_vpc_private-routetable-az3" {
   count                  = "${local.env_create_cloudplatform_routes}"
   route_table_id         = "${data.terraform_remote_state.vpc.vpc_private-routetable-az3}"
-  transit_gateway_id     = "${data.terraform_remote_state.common.transit_gateway_id}"
+  transit_gateway_id     = "${data.terraform_remote_state.common.pttp_transit_gateway_id}"
   destination_cidr_block = "${local.cloudplatform_cidr_range}"
-  count                  = "${local.env_create_cloudplatform_routes}"
 }
 
 resource "aws_route" "transit_gateway_route_vpc_db-routetable-az1" {
   count                  = "${local.env_create_cloudplatform_routes}"
   route_table_id         = "${data.terraform_remote_state.vpc.vpc_db-routetable-az1}"
-  transit_gateway_id     = "${data.terraform_remote_state.common.transit_gateway_id}"
+  transit_gateway_id     = "${data.terraform_remote_state.common.pttp_transit_gateway_id}"
   destination_cidr_block = "${local.cloudplatform_cidr_range}"
-  count                  = "${local.env_create_cloudplatform_routes}"
 }
 
 resource "aws_route" "transit_gateway_route_vpc_db-routetable-az2" {
   count                  = "${local.env_create_cloudplatform_routes}"
   route_table_id         = "${data.terraform_remote_state.vpc.vpc_db-routetable-az2}"
-  transit_gateway_id     = "${data.terraform_remote_state.common.transit_gateway_id}"
+  transit_gateway_id     = "${data.terraform_remote_state.common.pttp_transit_gateway_id}"
   destination_cidr_block = "${local.cloudplatform_cidr_range}"
-  count                  = "${local.env_create_cloudplatform_routes}"
 }
 
 resource "aws_route" "transit_gateway_route_vpc_db-routetable-az3" {
   count                  = "${local.env_create_cloudplatform_routes}"
   route_table_id         = "${data.terraform_remote_state.vpc.vpc_db-routetable-az3}"
-  transit_gateway_id     = "${data.terraform_remote_state.common.transit_gateway_id}"
+  transit_gateway_id     = "${data.terraform_remote_state.common.pttp_transit_gateway_id}"
   destination_cidr_block = "${local.cloudplatform_cidr_range}"
-  count                  = "${local.env_create_cloudplatform_routes}"
 }

--- a/transit-gateway-cloud-platform/routes-i2n.tf
+++ b/transit-gateway-cloud-platform/routes-i2n.tf
@@ -7,21 +7,21 @@
 resource "aws_route" "transit_gateway_route_vpc_private-routetable-az1-i2n-az1" {
   count                  = "${local.env_create_i2n_routes}"
   route_table_id         = "${data.terraform_remote_state.vpc.vpc_private-routetable-az1}"
-  transit_gateway_id     = "${data.terraform_remote_state.common.transit_gateway_id}"
+  transit_gateway_id     = "${data.terraform_remote_state.common.pttp_transit_gateway_id}"
   destination_cidr_block = "${local.i2n_az1_cidr_range}"
 }
 
 resource "aws_route" "transit_gateway_route_vpc_private-routetable-az2-i2n-az1" {
   count                  = "${local.env_create_i2n_routes}"
   route_table_id         = "${data.terraform_remote_state.vpc.vpc_private-routetable-az2}"
-  transit_gateway_id     = "${data.terraform_remote_state.common.transit_gateway_id}"
+  transit_gateway_id     = "${data.terraform_remote_state.common.pttp_transit_gateway_id}"
   destination_cidr_block = "${local.i2n_az1_cidr_range}"
 }
 
 resource "aws_route" "transit_gateway_route_vpc_private-routetable-az3-i2n-az1" {
   count                  = "${local.env_create_i2n_routes}"
   route_table_id         = "${data.terraform_remote_state.vpc.vpc_private-routetable-az3}"
-  transit_gateway_id     = "${data.terraform_remote_state.common.transit_gateway_id}"
+  transit_gateway_id     = "${data.terraform_remote_state.common.pttp_transit_gateway_id}"
   destination_cidr_block = "${local.i2n_az1_cidr_range}"
 }
 
@@ -31,21 +31,21 @@ resource "aws_route" "transit_gateway_route_vpc_private-routetable-az3-i2n-az1" 
 resource "aws_route" "transit_gateway_route_vpc_private-routetable-az1-i2n-az2" {
   count                  = "${local.env_create_i2n_routes}"
   route_table_id         = "${data.terraform_remote_state.vpc.vpc_private-routetable-az1}"
-  transit_gateway_id     = "${data.terraform_remote_state.common.transit_gateway_id}"
+  transit_gateway_id     = "${data.terraform_remote_state.common.pttp_transit_gateway_id}"
   destination_cidr_block = "${local.i2n_az2_cidr_range}"
 }
 
 resource "aws_route" "transit_gateway_route_vpc_private-routetable-az2-i2n-az2" {
   count                  = "${local.env_create_i2n_routes}"
   route_table_id         = "${data.terraform_remote_state.vpc.vpc_private-routetable-az2}"
-  transit_gateway_id     = "${data.terraform_remote_state.common.transit_gateway_id}"
+  transit_gateway_id     = "${data.terraform_remote_state.common.pttp_transit_gateway_id}"
   destination_cidr_block = "${local.i2n_az2_cidr_range}"
 }
 
 resource "aws_route" "transit_gateway_route_vpc_private-routetable-az3-i2n-az2" {
   count                  = "${local.env_create_i2n_routes}"
   route_table_id         = "${data.terraform_remote_state.vpc.vpc_private-routetable-az3}"
-  transit_gateway_id     = "${data.terraform_remote_state.common.transit_gateway_id}"
+  transit_gateway_id     = "${data.terraform_remote_state.common.pttp_transit_gateway_id}"
   destination_cidr_block = "${local.i2n_az2_cidr_range}"
 }
 
@@ -55,14 +55,14 @@ resource "aws_route" "transit_gateway_route_vpc_private-routetable-az3-i2n-az2" 
 resource "aws_route" "transit_gateway_route_vpc_private-routetable-az1-i2n-az3" {
   count                  = "${local.env_create_i2n_routes}"
   route_table_id         = "${data.terraform_remote_state.vpc.vpc_private-routetable-az1}"
-  transit_gateway_id     = "${data.terraform_remote_state.common.transit_gateway_id}"
+  transit_gateway_id     = "${data.terraform_remote_state.common.pttp_transit_gateway_id}"
   destination_cidr_block = "${local.i2n_az3_cidr_range}"
 }
 
 resource "aws_route" "transit_gateway_route_vpc_private-routetable-az2-i2n-az3" {
   count                  = "${local.env_create_i2n_routes}"
   route_table_id         = "${data.terraform_remote_state.vpc.vpc_private-routetable-az2}"
-  transit_gateway_id     = "${data.terraform_remote_state.common.transit_gateway_id}"
+  transit_gateway_id     = "${data.terraform_remote_state.common.pttp_transit_gateway_id}"
   destination_cidr_block = "${local.i2n_az3_cidr_range}"
 
 }
@@ -70,6 +70,6 @@ resource "aws_route" "transit_gateway_route_vpc_private-routetable-az2-i2n-az3" 
 resource "aws_route" "transit_gateway_route_vpc_private-routetable-az3-i2n-az3" {
   count                  = "${local.env_create_i2n_routes}"
   route_table_id         = "${data.terraform_remote_state.vpc.vpc_private-routetable-az3}"
-  transit_gateway_id     = "${data.terraform_remote_state.common.transit_gateway_id}"
+  transit_gateway_id     = "${data.terraform_remote_state.common.pttp_transit_gateway_id}"
   destination_cidr_block = "${local.i2n_az3_cidr_range}"
 }


### PR DESCRIPTION
Work item: https://dsdmoj.atlassian.net/browse/NIT-300

Results of tf plans against delius-core-dev

**transit-gateway-cloud-platform**
18 changed routes in VPC route tables. Each route has a changed transit_gateway_id
- 9 for i2n - one for each of the data, private and public subnets across the AZs
- 9 for cloud platform - 3 for each of the data, private and public subnets across the AZs, matching the equivalent i2n AZ CIDR range 

**transit-gateway-cloud-platform-test-rules** - none
**transit-gateway-analytics-platform-test-rules** - routes are not created in delius-core-dev (no matching AP environments)
**transit-gateway-analytics-platform-test-rules** - routes are not created in delius-core-dev (no matching AP environments)

 
