### PR TITLE
Update routes for AP to PTTP TGW and remove sandpit refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,6 @@ Applies the terraform code in the `transit-gateway-common` folder.
 tfrun delius-core-dev plan transit-gateway-common hmpps_token
 tfrun delius-core-dev apply transit-gateway-common hmpps_token
 
-# delius-core-sandpit
-tfrun delius-core-dev plan transit-gateway-common hmpps_token
-tfrun delius-core-dev apply transit-gateway-common hmpps_token
-
 # delius-stage
 tfrun delius-core-dev plan transit-gateway-common hmpps_token
 tfrun delius-core-dev apply transit-gateway-common hmpps_token
@@ -41,10 +37,6 @@ Apply the configuration in the `transit-gateway-cloud-platform` folder to create
 
 ```bash
 # delius-core-dev
-tfrun delius-core-dev plan transit-gateway-cloud-platform hmpps_token
-tfrun delius-core-dev apply transit-gateway-cloud-platform hmpps_token
-
-# delius-core-sandpit
 tfrun delius-core-dev plan transit-gateway-cloud-platform hmpps_token
 tfrun delius-core-dev apply transit-gateway-cloud-platform hmpps_token
 
@@ -70,10 +62,6 @@ Apply the configuration in the `transit-gateway-analytics-platform` folder to cr
 tfrun delius-core-dev plan transit-gateway-analytics-platform hmpps_token
 tfrun delius-core-dev apply transit-gateway-analytics-platform hmpps_token
 
-# delius-core-sandpit
-tfrun delius-core-dev plan transit-gateway-analytics-platform hmpps_token
-tfrun delius-core-dev apply transit-gateway-analytics-platform hmpps_token
-
 # delius-stage
 tfrun delius-core-dev plan transit-gateway-analytics-platform hmpps_token
 tfrun delius-core-dev apply transit-gateway-analytics-platform hmpps_token
@@ -91,10 +79,6 @@ tfrun delius-prod apply transit-gateway-analytics-platform hmpps_token
 
 ```bash
 # delius-core-dev
-tfrun delius-core-dev plan transit-gateway-cloud-platform-test-rules hmpps_token
-tfrun delius-core-dev apply transit-gateway-cloud-platform-test-rules hmpps_token
-
-# delius-core-sandpit
 tfrun delius-core-dev plan transit-gateway-cloud-platform-test-rules hmpps_token
 tfrun delius-core-dev apply transit-gateway-cloud-platform-test-rules hmpps_token
 
@@ -118,10 +102,6 @@ tfrun delius-prod apply transit-gateway-cloud-platform-test-rules hmpps_token
 tfrun delius-core-dev plan transit-gateway-analytics-platform-test-rules hmpps_token
 tfrun delius-core-dev apply transit-gateway-analytics-platform-test-rules hmpps_token
 
-# delius-core-sandpit
-tfrun delius-core-dev plan transit-gateway-analytics-platform-test-rules hmpps_token
-tfrun delius-core-dev apply transit-gateway-analytics-platform-test-rules hmpps_token
-
 # delius-stage
 tfrun delius-core-dev plan transit-gateway-analytics-platform-test-rules hmpps_token
 tfrun delius-core-dev apply transit-gateway-analytics-platform-test-rules hmpps_token
@@ -142,9 +122,6 @@ Warning: Terragrunt destroy won't prompt for destroy
 # delius-core-dev
 tfrun delius-core-dev destroy transit-gateway-cloud-platform-test-rules hmpps_token
 
-# delius-core-sandpit
-tfrun delius-core-dev destroy transit-gateway-cloud-platform-test-rules hmpps_token
-
 # delius-stage
 tfrun delius-core-dev destroy transit-gateway-cloud-platform-test-rules hmpps_token
 
@@ -161,9 +138,6 @@ Warning: Terragrunt destroy won't prompt for destroy
 
 ```bash
 # delius-core-dev
-tfrun delius-core-dev destroy transit-gateway-analytics-platform-test-rules hmpps_token
-
-# delius-core-sandpit
 tfrun delius-core-dev destroy transit-gateway-analytics-platform-test-rules hmpps_token
 
 # delius-stage

--- a/transit-gateway-analytics-platform-test-rules/locals.tf
+++ b/transit-gateway-analytics-platform-test-rules/locals.tf
@@ -17,14 +17,14 @@ locals {
 
   # Only create the security group rule to allow connectivity testing in these environments for Analytics ALPHA
   create_analytics_alpha_security_group_rules = {
-    delius-core-sandpit = "1"
+    # No environments required to test talking to AP alpha. Was delius-sandpit - but sandpit has now been removed
   }
 
   env_create_analytics_alpha_security_group_rules = "${lookup(local.create_analytics_alpha_security_group_rules, "${local.environment_name}" , 0) }"
 
   # Only create the security group rule to allow connectivity testing in these environments for Analytics DEV
   create_analytics_dev_security_group_rules = {
-    delius-core-sandpit = "1"
+    # No environments required to talk to AP dev - AP are moving towards having local dev dbs
   }
 
   env_create_analytics_dev_security_group_rules = "${lookup(local.create_analytics_dev_security_group_rules, "${local.environment_name}" , 0) }"

--- a/transit-gateway-analytics-platform/locals.tf
+++ b/transit-gateway-analytics-platform/locals.tf
@@ -34,7 +34,7 @@ locals {
   env_create_analytics_alpha_routes = "${lookup(local.create_analytics_alpha_routes, "${local.environment_name}" , 0) }"
 
   create_analytics_dev_routes = {
-    delius-core-sandpit = "1"
+    # No environments required to talk to AP dev - AP are moving towards having local dev dbs
   }
   env_create_analytics_dev_routes = "${lookup(local.create_analytics_dev_routes, "${local.environment_name}" , 0) }"
 
@@ -57,7 +57,7 @@ locals {
 
   # Only create the security group ingress in these environments for Analytics DEV
   create_analytics_dev_security_group_ingress = {
-    delius-core-sandpit = "1"
+    # No environments required to talk to AP dev - AP are moving towards having local dev dbs
   }
   env_create_analytics_dev_security_group_ingress = "${lookup(local.create_analytics_dev_security_group_ingress, "${local.environment_name}" , 0) }"
 

--- a/transit-gateway-analytics-platform/routes-analytical-platform-alpha.tf
+++ b/transit-gateway-analytics-platform/routes-analytical-platform-alpha.tf
@@ -4,63 +4,63 @@
 #================================================
 // resource "aws_route" "transit_gateway_route_vpc_public-routetable-az1-apde-alpha" {
 //   route_table_id         = "${data.terraform_remote_state.vpc.vpc_public-routetable-az1}"
-//   transit_gateway_id     = "${data.terraform_remote_state.common.transit_gateway_id}"
+//   transit_gateway_id     = "${data.terraform_remote_state.common.pttp_transit_gateway_id}"
 //   destination_cidr_block = "${local.analyticalplatform_alpha_cidr_range}"
 //   count                  = "${local.env_create_analytics_alpha_routes}"
 // }
 
 // resource "aws_route" "transit_gateway_route_vpc_public-routetable-az2-apde-alpha" {
 //   route_table_id         = "${data.terraform_remote_state.vpc.vpc_public-routetable-az2}"
-//   transit_gateway_id     = "${data.terraform_remote_state.common.transit_gateway_id}"
+//   transit_gateway_id     = "${data.terraform_remote_state.common.pttp_transit_gateway_id}"
 //   destination_cidr_block = "${local.analyticalplatform_alpha_cidr_range}"
 //   count                  = "${local.env_create_analytics_alpha_routes}"
 // }
 
 // resource "aws_route" "transit_gateway_route_vpc_public-routetable-az3-apde-alpha" {
 //   route_table_id         = "${data.terraform_remote_state.vpc.vpc_public-routetable-az3}"
-//   transit_gateway_id     = "${data.terraform_remote_state.common.transit_gateway_id}"
+//   transit_gateway_id     = "${data.terraform_remote_state.common.pttp_transit_gateway_id}"
 //   destination_cidr_block = "${local.analyticalplatform_alpha_cidr_range}"
 //   count                  = "${local.env_create_analytics_alpha_routes}"
 // }
 
 // resource "aws_route" "transit_gateway_route_vpc_private-routetable-az1-apde-alpha" {
 //   route_table_id         = "${data.terraform_remote_state.vpc.vpc_private-routetable-az1}"
-//   transit_gateway_id     = "${data.terraform_remote_state.common.transit_gateway_id}"
+//   transit_gateway_id     = "${data.terraform_remote_state.common.pttp_transit_gateway_id}"
 //   destination_cidr_block = "${local.analyticalplatform_alpha_cidr_range}"
 //   count                  = "${local.env_create_analytics_alpha_routes}"
 // }
 
 // resource "aws_route" "transit_gateway_route_vpc_private-routetable-az2-apde-alpha" {
 //   route_table_id         = "${data.terraform_remote_state.vpc.vpc_private-routetable-az2}"
-//   transit_gateway_id     = "${data.terraform_remote_state.common.transit_gateway_id}"
+//   transit_gateway_id     = "${data.terraform_remote_state.common.pttp_transit_gateway_id}"
 //   destination_cidr_block = "${local.analyticalplatform_alpha_cidr_range}"
 //   count                  = "${local.env_create_analytics_alpha_routes}"
 // }
 
 // resource "aws_route" "transit_gateway_route_vpc_private-routetable-az3-apde-alpha" {
 //   route_table_id         = "${data.terraform_remote_state.vpc.vpc_private-routetable-az3}"
-//   transit_gateway_id     = "${data.terraform_remote_state.common.transit_gateway_id}"
+//   transit_gateway_id     = "${data.terraform_remote_state.common.pttp_transit_gateway_id}"
 //   destination_cidr_block = "${local.analyticalplatform_alpha_cidr_range}"
 //   count                  = "${local.env_create_analytics_alpha_routes}"
 // }
 
 // resource "aws_route" "transit_gateway_route_vpc_db-routetable-az1-apde-alpha" {
 //   route_table_id         = "${data.terraform_remote_state.vpc.vpc_db-routetable-az1}"
-//   transit_gateway_id     = "${data.terraform_remote_state.common.transit_gateway_id}"
+//   transit_gateway_id     = "${data.terraform_remote_state.common.pttp_transit_gateway_id}"
 //   destination_cidr_block = "${local.analyticalplatform_alpha_cidr_range}"
 //   count                  = "${local.env_create_analytics_alpha_routes}"
 // }
 
 // resource "aws_route" "transit_gateway_route_vpc_db-routetable-az2-apde-alpha" {
 //   route_table_id         = "${data.terraform_remote_state.vpc.vpc_db-routetable-az2}"
-//   transit_gateway_id     = "${data.terraform_remote_state.common.transit_gateway_id}"
+//   transit_gateway_id     = "${data.terraform_remote_state.common.pttp_transit_gateway_id}"
 //   destination_cidr_block = "${local.analyticalplatform_alpha_cidr_range}"
 //   count                  = "${local.env_create_analytics_alpha_routes}"
 // }
 
 resource "aws_route" "transit_gateway_route_vpc_db-routetable-az3-apde-alpha" {
   route_table_id         = "${data.terraform_remote_state.vpc.vpc_db-routetable-az3}"
-  transit_gateway_id     = "${data.terraform_remote_state.common.transit_gateway_id}"
+  transit_gateway_id     = "${data.terraform_remote_state.common.pttp_transit_gateway_id}"
   destination_cidr_block = "${local.analyticalplatform_alpha_cidr_range}"
   count                  = "${local.env_create_analytics_alpha_routes}"
 }

--- a/transit-gateway-analytics-platform/routes-analytical-platform-pre-prod.tf
+++ b/transit-gateway-analytics-platform/routes-analytical-platform-pre-prod.tf
@@ -1,66 +1,66 @@
 #================================================
-# Routes to Analytical Platform Data Engineering (prod)
+# Routes to Analytical Platform Data Engineering (pre-prod)
 # Routes to Public, Private & db subnets 
 #================================================
-// resource "aws_route" "transit_gateway_route_vpc_public-routetable-az1-apde-prod" {
+// resource "aws_route" "transit_gateway_route_vpc_public-routetable-az1-apde-pre-prod" {
 //   route_table_id         = "${data.terraform_remote_state.vpc.vpc_public-routetable-az1}"
-//   transit_gateway_id     = "${data.terraform_remote_state.common.transit_gateway_id}"
-//   destination_cidr_block = "${local.analyticalplatform_prod_cidr_range}"
-//   count                  = "${local.env_create_analytics_prod_routes}"
+//   transit_gateway_id     = "${data.terraform_remote_state.common.pttp_transit_gateway_id}"
+//   destination_cidr_block = "${local.analyticalplatform_pre_prod_cidr_range}"
+//   count                  = "${local.env_create_analytics_pre_prod_routes}"
 // }
 
-// resource "aws_route" "transit_gateway_route_vpc_public-routetable-az2-apde-prod" {
+// resource "aws_route" "transit_gateway_route_vpc_public-routetable-az2-apde-pre-prod" {
 //   route_table_id         = "${data.terraform_remote_state.vpc.vpc_public-routetable-az2}"
-//   transit_gateway_id     = "${data.terraform_remote_state.common.transit_gateway_id}"
-//   destination_cidr_block = "${local.analyticalplatform_prod_cidr_range}"
-//   count                  = "${local.env_create_analytics_prod_routes}"
+//   transit_gateway_id     = "${data.terraform_remote_state.common.pttp_transit_gateway_id}"
+//   destination_cidr_block = "${local.analyticalplatform_pre_prod_cidr_range}"
+//   count                  = "${local.env_create_analytics_pre_prod_routes}"
 // }
 
-// resource "aws_route" "transit_gateway_route_vpc_public-routetable-az3-apde-prod" {
+// resource "aws_route" "transit_gateway_route_vpc_public-routetable-az3-apde-pre-prod" {
 //   route_table_id         = "${data.terraform_remote_state.vpc.vpc_public-routetable-az3}"
-//   transit_gateway_id     = "${data.terraform_remote_state.common.transit_gateway_id}"
-//   destination_cidr_block = "${local.analyticalplatform_prod_cidr_range}"
-//   count                  = "${local.env_create_analytics_prod_routes}"
+//   transit_gateway_id     = "${data.terraform_remote_state.common.pttp_transit_gateway_id}"
+//   destination_cidr_block = "${local.analyticalplatform_pre_prod_cidr_range}"
+//   count                  = "${local.env_create_analytics_pre_prod_routes}"
 // }
 
-// resource "aws_route" "transit_gateway_route_vpc_private-routetable-az1-apde-prod" {
+// resource "aws_route" "transit_gateway_route_vpc_private-routetable-az1-apde-pre-prod" {
 //   route_table_id         = "${data.terraform_remote_state.vpc.vpc_private-routetable-az1}"
-//   transit_gateway_id     = "${data.terraform_remote_state.common.transit_gateway_id}"
-//   destination_cidr_block = "${local.analyticalplatform_prod_cidr_range}"
-//   count                  = "${local.env_create_analytics_prod_routes}"
+//   transit_gateway_id     = "${data.terraform_remote_state.common.pttp_transit_gateway_id}"
+//   destination_cidr_block = "${local.analyticalplatform_pre_prod_cidr_range}"
+//   count                  = "${local.env_create_analytics_pre_prod_routes}"
 // }
 
-// resource "aws_route" "transit_gateway_route_vpc_private-routetable-az2-apde-prod" {
+// resource "aws_route" "transit_gateway_route_vpc_private-routetable-az2-apde-pre-prod" {
 //   route_table_id         = "${data.terraform_remote_state.vpc.vpc_private-routetable-az2}"
-//   transit_gateway_id     = "${data.terraform_remote_state.common.transit_gateway_id}"
-//   destination_cidr_block = "${local.analyticalplatform_prod_cidr_range}"
-//   count                  = "${local.env_create_analytics_prod_routes}"
+//   transit_gateway_id     = "${data.terraform_remote_state.common.pttp_transit_gateway_id}"
+//   destination_cidr_block = "${local.analyticalplatform_pre_prod_cidr_range}"
+//   count                  = "${local.env_create_analytics_pre_prod_routes}"
 // }
 
-// resource "aws_route" "transit_gateway_route_vpc_private-routetable-az3-apde-prod" {
+// resource "aws_route" "transit_gateway_route_vpc_private-routetable-az3-apde-pre-prod" {
 //   route_table_id         = "${data.terraform_remote_state.vpc.vpc_private-routetable-az3}"
-//   transit_gateway_id     = "${data.terraform_remote_state.common.transit_gateway_id}"
-//   destination_cidr_block = "${local.analyticalplatform_prod_cidr_range}"
-//   count                  = "${local.env_create_analytics_prod_routes}"
+//   transit_gateway_id     = "${data.terraform_remote_state.common.pttp_transit_gateway_id}"
+//   destination_cidr_block = "${local.analyticalplatform_pre_prod_cidr_range}"
+//   count                  = "${local.env_create_analytics_pre_prod_routes}"
 // }
 
-// resource "aws_route" "transit_gateway_route_vpc_db-routetable-az1-apde-prod" {
+// resource "aws_route" "transit_gateway_route_vpc_db-routetable-az1-apde-pre-prod" {
 //   route_table_id         = "${data.terraform_remote_state.vpc.vpc_db-routetable-az1}"
-//   transit_gateway_id     = "${data.terraform_remote_state.common.transit_gateway_id}"
-//   destination_cidr_block = "${local.analyticalplatform_prod_cidr_range}"
-//   count                  = "${local.env_create_analytics_prod_routes}"
+//   transit_gateway_id     = "${data.terraform_remote_state.common.pttp_transit_gateway_id}"
+//   destination_cidr_block = "${local.analyticalplatform_pre_prod_cidr_range}"
+//   count                  = "${local.env_create_analytics_pre_prod_routes}"
 // }
 
 resource "aws_route" "transit_gateway_route_vpc_db-routetable-az2-apde-pre-prod" {
    route_table_id         = "${data.terraform_remote_state.vpc.vpc_db-routetable-az2}"
-   transit_gateway_id     = "${data.terraform_remote_state.common.transit_gateway_id}"
+   transit_gateway_id     = "${data.terraform_remote_state.common.pttp_transit_gateway_id}"
    destination_cidr_block = "${local.analyticalplatform_pre_prod_cidr_range}"
    count                  = "${local.env_create_analytics_pre_prod_routes}"
 }
 
 resource "aws_route" "transit_gateway_route_vpc_db-routetable-az3-apde-pre-prod" {
   route_table_id         = "${data.terraform_remote_state.vpc.vpc_db-routetable-az3}"
-  transit_gateway_id     = "${data.terraform_remote_state.common.transit_gateway_id}"
+  transit_gateway_id     = "${data.terraform_remote_state.common.pttp_transit_gateway_id}"
   destination_cidr_block = "${local.analyticalplatform_pre_prod_cidr_range}"
   count                  = "${local.env_create_analytics_pre_prod_routes}"
 }

--- a/transit-gateway-analytics-platform/routes-analytical-platform-prod.tf
+++ b/transit-gateway-analytics-platform/routes-analytical-platform-prod.tf
@@ -4,63 +4,63 @@
 #================================================
 // resource "aws_route" "transit_gateway_route_vpc_public-routetable-az1-apde-prod" {
 //   route_table_id         = "${data.terraform_remote_state.vpc.vpc_public-routetable-az1}"
-//   transit_gateway_id     = "${data.terraform_remote_state.common.transit_gateway_id}"
+//   transit_gateway_id     = "${data.terraform_remote_state.common.pttp_transit_gateway_id}"
 //   destination_cidr_block = "${local.analyticalplatform_prod_cidr_range}"
 //   count                  = "${local.env_create_analytics_prod_routes}"
 // }
 
 // resource "aws_route" "transit_gateway_route_vpc_public-routetable-az2-apde-prod" {
 //   route_table_id         = "${data.terraform_remote_state.vpc.vpc_public-routetable-az2}"
-//   transit_gateway_id     = "${data.terraform_remote_state.common.transit_gateway_id}"
+//   transit_gateway_id     = "${data.terraform_remote_state.common.pttp_transit_gateway_id}"
 //   destination_cidr_block = "${local.analyticalplatform_prod_cidr_range}"
 //   count                  = "${local.env_create_analytics_prod_routes}"
 // }
 
 // resource "aws_route" "transit_gateway_route_vpc_public-routetable-az3-apde-prod" {
 //   route_table_id         = "${data.terraform_remote_state.vpc.vpc_public-routetable-az3}"
-//   transit_gateway_id     = "${data.terraform_remote_state.common.transit_gateway_id}"
+//   transit_gateway_id     = "${data.terraform_remote_state.common.pttp_transit_gateway_id}"
 //   destination_cidr_block = "${local.analyticalplatform_prod_cidr_range}"
 //   count                  = "${local.env_create_analytics_prod_routes}"
 // }
 
 // resource "aws_route" "transit_gateway_route_vpc_private-routetable-az1-apde-prod" {
 //   route_table_id         = "${data.terraform_remote_state.vpc.vpc_private-routetable-az1}"
-//   transit_gateway_id     = "${data.terraform_remote_state.common.transit_gateway_id}"
+//   transit_gateway_id     = "${data.terraform_remote_state.common.pttp_transit_gateway_id}"
 //   destination_cidr_block = "${local.analyticalplatform_prod_cidr_range}"
 //   count                  = "${local.env_create_analytics_prod_routes}"
 // }
 
 // resource "aws_route" "transit_gateway_route_vpc_private-routetable-az2-apde-prod" {
 //   route_table_id         = "${data.terraform_remote_state.vpc.vpc_private-routetable-az2}"
-//   transit_gateway_id     = "${data.terraform_remote_state.common.transit_gateway_id}"
+//   transit_gateway_id     = "${data.terraform_remote_state.common.pttp_transit_gateway_id}"
 //   destination_cidr_block = "${local.analyticalplatform_prod_cidr_range}"
 //   count                  = "${local.env_create_analytics_prod_routes}"
 // }
 
 // resource "aws_route" "transit_gateway_route_vpc_private-routetable-az3-apde-prod" {
 //   route_table_id         = "${data.terraform_remote_state.vpc.vpc_private-routetable-az3}"
-//   transit_gateway_id     = "${data.terraform_remote_state.common.transit_gateway_id}"
+//   transit_gateway_id     = "${data.terraform_remote_state.common.pttp_transit_gateway_id}"
 //   destination_cidr_block = "${local.analyticalplatform_prod_cidr_range}"
 //   count                  = "${local.env_create_analytics_prod_routes}"
 // }
 
 // resource "aws_route" "transit_gateway_route_vpc_db-routetable-az1-apde-prod" {
 //   route_table_id         = "${data.terraform_remote_state.vpc.vpc_db-routetable-az1}"
-//   transit_gateway_id     = "${data.terraform_remote_state.common.transit_gateway_id}"
+//   transit_gateway_id     = "${data.terraform_remote_state.common.pttp_transit_gateway_id}"
 //   destination_cidr_block = "${local.analyticalplatform_prod_cidr_range}"
 //   count                  = "${local.env_create_analytics_prod_routes}"
 // }
 
 // resource "aws_route" "transit_gateway_route_vpc_db-routetable-az2-apde-prod" {
 //   route_table_id         = "${data.terraform_remote_state.vpc.vpc_db-routetable-az2}"
-//   transit_gateway_id     = "${data.terraform_remote_state.common.transit_gateway_id}"
+//   transit_gateway_id     = "${data.terraform_remote_state.common.pttp_transit_gateway_id}"
 //   destination_cidr_block = "${local.analyticalplatform_prod_cidr_range}"
 //   count                  = "${local.env_create_analytics_prod_routes}"
 // }
 
 resource "aws_route" "transit_gateway_route_vpc_db-routetable-az3-apde-prod" {
   route_table_id         = "${data.terraform_remote_state.vpc.vpc_db-routetable-az3}"
-  transit_gateway_id     = "${data.terraform_remote_state.common.transit_gateway_id}"
+  transit_gateway_id     = "${data.terraform_remote_state.common.pttp_transit_gateway_id}"
   destination_cidr_block = "${local.analyticalplatform_prod_cidr_range}"
   count                  = "${local.env_create_analytics_prod_routes}"
 }

--- a/transit-gateway-cloud-platform-test-rules/locals.tf
+++ b/transit-gateway-cloud-platform-test-rules/locals.tf
@@ -12,7 +12,6 @@ locals {
   # Only create the security group rule to allow connectivity testing in these environments for Cloudplatform
   create_cloudplatform_security_group_rules = {
     delius-core-dev     = "1"
-    delius-core-sandpit = "1"
     delius-stage        = "1"
     delius-pre-prod     = "1"
     delius-prod         = "1"

--- a/transit-gateway-cloud-platform/locals.tf
+++ b/transit-gateway-cloud-platform/locals.tf
@@ -23,7 +23,6 @@ locals {
   # Only create the routes to allow connectivity testing in these environments for Cloudplatform
   create_cloudplatform_routes = {
     delius-core-dev     = "1"
-    delius-core-sandpit = "1"
     delius-stage        = "1"
     delius-pre-prod     = "1"
     delius-prod         = "1"


### PR DESCRIPTION
Work item: https://dsdmoj.atlassian.net/browse/NIT-371

Point Analytical Platform routes to PTTP TGW (will take affect in delius pre-prod and prod envs)
Also removed sandpit references

TF plans show
- stage: 18 RT routes changed (9 for Cloud Platform, 9 for i2n) (from previous PR - #25  - not yet applied)
- pre-prod: 9 RT routes changed (9 for Cloud Platform); 4 RT routes for Analytical Platform
- prod: 19 RT routes changed (9 for Cloud Platform, 9 for i2n); 1 RT route for Analytical Platform
