### PR TITLE
Remove legacy TGW VPC attachment

### DIFF
--- a/transit-gateway-cloud-platform-test-rules/locals.tf
+++ b/transit-gateway-cloud-platform-test-rules/locals.tf
@@ -3,8 +3,6 @@
 locals {
   environment_name = "${var.project_name}-${var.environment_type}"
   account_ids      = "${var.aws_account_ids}"
-  #transit_gateway_id = "${data.terraform_remote_state.common.transit_gateway_id}"
-  #transit_gateway_attachment_name = "tgwa-${local.environment_name}-cloudplatform"
   vpc_id = "${data.terraform_remote_state.vpc.vpc_id}"
 
   cloudplatform_cidr_range        = "172.20.0.0/16"

--- a/transit-gateway-cloud-platform/locals.tf
+++ b/transit-gateway-cloud-platform/locals.tf
@@ -3,8 +3,6 @@
 locals {
   environment_name = "${var.project_name}-${var.environment_type}"
   account_ids      = "${var.aws_account_ids}"
-  #transit_gateway_id = "${data.terraform_remote_state.common.transit_gateway_id}"
-  #transit_gateway_attachment_name = "tgwa-${local.environment_name}-cloudplatform"
   vpc_id = "${data.terraform_remote_state.vpc.vpc_id}"
 
 

--- a/transit-gateway-common/locals.tf
+++ b/transit-gateway-common/locals.tf
@@ -4,8 +4,8 @@ locals {
   environment_name = "${var.project_name}-${var.environment_type}"
   account_ids      = "${var.aws_account_ids}"
 
-  transit_gateway_id              = "tgw-05acb84d26b244813"
-  transit_gateway_attachment_name = "tgwa-${local.environment_name}"
+  # transit_gateway_id              = "tgw-05acb84d26b244813"
+  # transit_gateway_attachment_name = "tgwa-${local.environment_name}"
   pttp_transit_gateway_id              = "tgw-026162f1ba39ce704"
   pttp_transit_gateway_attachment_name = "pttp-tgwa-${local.environment_name}"
 

--- a/transit-gateway-common/main.tf
+++ b/transit-gateway-common/main.tf
@@ -1,26 +1,4 @@
 #===================================
-# Transit Gateway VPC Attachments
-#===================================
-resource "aws_ec2_transit_gateway_vpc_attachment" "delius_transit_gw_attachment" {
-  subnet_ids         = ["${local.private_subnets}"]
-  transit_gateway_id = "${local.transit_gateway_id}"
-  vpc_id             = "${local.vpc_id}"
-
-  dns_support  = "enable"
-  ipv6_support = "disable"
-
-  transit_gateway_default_route_table_association = "true"
-  transit_gateway_default_route_table_propagation = "true"
-
-  tags = "${merge(
-    local.tags,
-    map(
-        "Name", "${local.transit_gateway_attachment_name}"
-    )
-  )}"
-}
-
-#===================================
 # PTTP Transit Gateway VPC Attachments
 #===================================
 resource "aws_ec2_transit_gateway_vpc_attachment" "delius_pttp_transit_gw_attachment" {

--- a/transit-gateway-common/outputs.tf
+++ b/transit-gateway-common/outputs.tf
@@ -1,7 +1,3 @@
-output "transit_gateway_id" {
-  value = "${local.transit_gateway_id}"
-}
-
 output "pttp_transit_gateway_id" {
   value = "${local.pttp_transit_gateway_id}"
 }


### PR DESCRIPTION
Workitem: nit-435
Removing the legacy transit gateway attachments from VPC.
Routes to this TGW have been removed with the exception of a single route in core-dev in a route table that's not associated with any subnet.
e.g.
```aws ec2 describe-route-tables --filter "Name=route.transit-gateway-id,Values=tgw-05acb84d26b244813" --profile <profile>```