### PR TITLE
NIT-926 enable routing between mis-dev and cloud platform

### DIFF
--- a/transit-gateway-cloud-platform-test-rules/locals.tf
+++ b/transit-gateway-cloud-platform-test-rules/locals.tf
@@ -5,17 +5,16 @@ locals {
   account_ids      = "${var.aws_account_ids}"
   vpc_id = "${data.terraform_remote_state.vpc.vpc_id}"
 
-  cloudplatform_cidr_range        = "172.20.0.0/16"
+  cloudplatform_cidr_range = "172.20.0.0/16"
 
   # Only create the security group rule to allow connectivity testing in these environments for Cloudplatform
   create_cloudplatform_security_group_rules = {
-    delius-core-dev     = "1"
-    delius-test         = "1"
-    delius-stage        = "1"
-    delius-pre-prod     = "1"
-    delius-prod         = "1"
+    delius-mis-dev  = "1"
+    delius-test     = "1"
+    delius-stage    = "1"
+    delius-pre-prod = "1"
+    delius-prod     = "1"
   }
 
   env_create_cloudplatform_security_group_rules = "${lookup(local.create_cloudplatform_security_group_rules, "${local.environment_name}" , 0) }"
-  
 }

--- a/transit-gateway-cloud-platform/locals.tf
+++ b/transit-gateway-cloud-platform/locals.tf
@@ -20,18 +20,18 @@ locals {
 
   # Only create the routes to allow connectivity testing in these environments for Cloudplatform
   create_cloudplatform_routes = {
-    delius-core-dev     = "1"
-    delius-test         = "1"
-    delius-stage        = "1"
-    delius-pre-prod     = "1"
-    delius-prod         = "1"
+    delius-mis-dev  = "1"
+    delius-test     = "1"
+    delius-stage    = "1"
+    delius-pre-prod = "1"
+    delius-prod     = "1"
   }
   env_create_cloudplatform_routes = "${lookup(local.create_cloudplatform_routes, "${local.environment_name}" , 0) }"
 
   create_i2n_routes = {
-    delius-core-dev     = "1"
-    delius-stage        = "1"
-    delius-prod         = "1"
+    delius-mis-dev  = "1"
+    delius-stage    = "1"
+    delius-prod     = "1"
   }
   env_create_i2n_routes = "${lookup(local.create_i2n_routes, "${local.environment_name}" , 0) }"
 

--- a/transit-gateway-modernisation-platform/locals.tf
+++ b/transit-gateway-modernisation-platform/locals.tf
@@ -15,9 +15,8 @@ locals {
 
   # Only create the routes to allow connectivity testing in these environments for modernisation platform
   create_modplatform_routes_low = {
-    delius-core-dev = "1"
-    delius-mis-dev  = "1"
-    delius-test     = "1"
+    delius-mis-dev = "1"
+    delius-test    = "1"
   }
   env_create_modplatform_routes_low = "${lookup(local.create_modplatform_routes_low, "${local.environment_name}", 0)}"
 


### PR DESCRIPTION
Additionally remove references to core-dev which has been decommissioned